### PR TITLE
SourceForge and snapshot [skip ci]

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -36,6 +36,7 @@ class LibdwarfConan(ConanFile):
         del self.settings.compiler.libcxx
 
     def source(self):
+        # INFO (uilian): SourceForge doesn't allow permanent link for code snapshot
         source_url = "https://dl.bintray.com/bincrafters/public-sources"
         commit = "c6660d75c2affc3e2f1231ad55942734060d98e6"
         sha256 = "7f0bc94c82bb3130f4a3d20e14ccb45656ad54d412c8b2edfc3d33981803a72d"


### PR DESCRIPTION
- The author didn't create releases on Source Forge, we only
  are able to create a code snapshot based on git tags.
  The snapshot works like a temporary link, we download, but
  after few hours is not longer available.
- To fix this situation, I've uploaded the source code to Bintray.
